### PR TITLE
debug git environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ LABEL com.github.actions.description="Print a bunch of useful info about your en
 LABEL com.github.actions.icon="life-bouy"
 LABEL com.github.actions.color="red"
 
-RUN apt-get update && apt-get install -y jq tree
+RUN apt-get update && apt-get install -y git jq tree
 
-COPY . /
+WORKDIR /debug-action
+COPY . .
 
-ENTRYPOINT "/entrypoint.sh"
-CMD ["debug"]
+ENTRYPOINT ["/debug-action/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ LABEL maintainer="Shawn Allen <shawnbot@github.com>"
 
 LABEL com.github.actions.name="Debug Node Environment"
 LABEL com.github.actions.description="Print a bunch of useful info about your environment"
-LABEL com.github.actions.icon="life-bouy"
-LABEL com.github.actions.color="red"
+LABEL com.github.actions.icon="coffee"
+LABEL com.github.actions.color="white"
 
 RUN apt-get update && apt-get install -y git jq tree
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,10 @@ echo "args: '$*'"
 # where am I?
 pwd
 
+# debug some git stuff
+git status
+git config --list
+
 # print environment variables
 env
 


### PR DESCRIPTION
This installs the `git` binaries, runs some debugging commands, and bootstraps everything out of the `/debug-action` directory rather than `/`, to avoid clobbering files created by other actions.